### PR TITLE
minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,6 @@ set(CMAKE_CXX_FLAGS "-O3 -msse2 -msse3")
 
 # Set optimized building:
 IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native -mavx")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native")
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,33 @@ find_package(Pangolin 0.1 REQUIRED)
 #Find dependencies (Eigen is included in MRPT)
 find_package(MRPT REQUIRED base obs)
 find_package(OpenCV REQUIRED)
-find_package(OpenNI2 REQUIRED)
+find_package(OpenNI2)
+
+if(NOT OpenNI2_FOUND)
+    message(STATUS "OpenNI2 not found. Will not use online live mode.")
+endif()
+
 
 set(sfusion_SHADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Shaders" CACHE PATH "Where the shaders live")
 
 include_directories(${PROJECT_SOURCE_DIR})
-include_directories(${OpenNI2_INCLUDE_DIRS})
+if(OpenNI2_FOUND)
+    include_directories(${OpenNI2_INCLUDE_DIRS})
+endif()
 
 include_directories(${Pangolin_INCLUDE_DIRS})
 include_directories(${EIGEN_INCLUDE_DIRS})
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-file(GLOB sf_utils_srcs Utils/*)
+set(sf_utils_srcs
+    "Utils/Datasets.cpp"
+    "Utils/GPUTexture.cpp"
+    "Utils/Parse.cpp"
+)
+if(OpenNI2_FOUND)
+    list(APPEND sf_utils_srcs "Utils/RGBD_Camera.cpp")
+endif()
+
 file(GLOB sf_shader_srcs Shaders/*.cpp)
 
 file(GLOB sf_srcs 
@@ -53,14 +68,19 @@ ADD_LIBRARY(sf_lib
 	
 TARGET_LINK_LIBRARIES(sf_lib
 	${MRPT_LIBS}
-	${OpenNI2_LIBRARY}
 	${OpenCV_LIBS}
    	${Pangolin_LIBRARIES}
 )
+
+if(OpenNI2_FOUND)
+    TARGET_LINK_LIBRARIES(sf_lib ${OpenNI2_LIBRARY})
+endif()
 		
-#To run online with an RGB-D camera	
-ADD_EXECUTABLE(StaticFusion-Camera 	StaticFusion-camera.cpp)	
-TARGET_LINK_LIBRARIES(StaticFusion-Camera 	sf_lib)
+#To run online with an RGB-D camera
+if(OpenNI2_FOUND)
+    ADD_EXECUTABLE(StaticFusion-Camera 	StaticFusion-camera.cpp)
+    TARGET_LINK_LIBRARIES(StaticFusion-Camera 	sf_lib)
+endif()
 		
 #To test it with the TUM dataset		
 ADD_EXECUTABLE(StaticFusion-Datasets 	StaticFusion-datasets.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)  # Required by CMake 2.7+
 endif(COMMAND cmake_policy)
 
+set(CMAKE_CXX_STANDARD 11)
+
 # custom cmake modules
 LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
 
@@ -67,12 +69,13 @@ TARGET_LINK_LIBRARIES(StaticFusion-Datasets 	sf_lib)
 #To test it with pre-recorded RGB-D sequences		
 ADD_EXECUTABLE(StaticFusion-ImageSeqAssoc 	StaticFusion-imagesequenceassoc.cpp)
 TARGET_LINK_LIBRARIES(StaticFusion-ImageSeqAssoc 	sf_lib)
+
+add_definitions(-DSHADER_DIR="${sfusion_SHADER_DIR}")
 		
-set(CMAKE_CXX_FLAGS "-O3 -msse2 -msse3 -std=c++11 -DSHADER_DIR=${sfusion_SHADER_DIR}")		
+set(CMAKE_CXX_FLAGS "-O3 -msse2 -msse3")
 
 # Set optimized building:
 IF(CMAKE_COMPILER_IS_GNUCXX)
-	SET(CMAKE_BUILD_TYPE "Release")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mtune=native -mavx -std=c++11")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native -mavx")
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 PROJECT(static-fusion)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)  # Required by CMake 2.7+
 endif(COMMAND cmake_policy)

--- a/FrontEnd.cpp
+++ b/FrontEnd.cpp
@@ -906,7 +906,7 @@ void StaticFusion::computeResidualsAgainstPreviousImage(int index) {
     }
 
     T = T * T_odometry;
-    T = T.inverse();
+    T = T.inverse().eval();
 
     int valid_pixels = 0;
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,15 @@ There are three executables you can run:
 
 **1) StaticFusion-Camera:** running off of live RGB-D camera feed, assuming an OpenNI compatible camera.
 
-**2) StaticFusion-Datasets:** running using the TUM/Freiburg RGB-D datasets in Rawlog format. You can download these sequeces [here](https://www.mrpt.org/Collection_of_Kinect_RGBD_datasets_with_ground_truth_CVPR_TUM_2011). If you would like to perform quantitative evaluation, set ```bool save_results = true``` within the ```StaticFusion-datasets.cpp``` file to save the estimated trajectory to file. This trajectory can then be evaluated here: http://vision.in.tum.de/data/datasets/rgbd-dataset/online_evaluation
+**2) StaticFusion-Datasets:** running using the TUM/Freiburg RGB-D datasets in Rawlog format.
 
-**2) StaticFusion-ImageSequenceAssoc:** running using images stored on disk. The expected format for images in this case is the same as listed [here](https://vision.in.tum.de/data/datasets/rgbd-dataset/tools) if one was to use ```associate.py``` script to associate color and depth images.
+   - run: `./StaticFusion-Datasets ~/Downloads/rawlog_rgbd_dataset_freiburg1_360/rgbd_dataset_freiburg1_360.rawlog`
+   - You can download these sequeces [here](https://www.mrpt.org/Collection_of_Kinect_RGBD_datasets_with_ground_truth_CVPR_TUM_2011). If you would like to perform quantitative evaluation, set ```bool save_results = true``` within the ```StaticFusion-datasets.cpp``` file to save the estimated trajectory to file. This trajectory can then be evaluated here: http://vision.in.tum.de/data/datasets/rgbd-dataset/online_evaluation.
+
+**2) StaticFusion-ImageSequenceAssoc:** running using images stored on disk.
+
+   - run: `./StaticFusion-ImageSeqAssoc ~/Downloads/ball`
+   - The expected format for images in this case is the same as listed [here](https://vision.in.tum.de/data/datasets/rgbd-dataset/tools) if one was to use ```associate.py``` script to associate color and depth images.
 
 The organisational structure of the dataset should be:
 

--- a/SegmentationBackground.cpp
+++ b/SegmentationBackground.cpp
@@ -179,6 +179,12 @@ void StaticFusion::buildSegmImage()
     const MatrixXi &labels_maxres = clusterAllocation[0];
     for (unsigned int u=0; u<cols; u++)
         for (unsigned int v=0; v<rows; v++) {
+            if (labels_maxres(v,u)==NUM_CLUSTERS) {
+                // assume static for invalid cluster
+                b_segm_perpixel(v,u) = 1;
+                continue;
+            }
+
             b_segm_perpixel(v,u) = max(0.f, min(1.f, b_segm[labels_maxres(v,u)]));
 
             if ( perClusterAverageResidual(labels_maxres(v, u)) < 0.017) {

--- a/StaticFusion-datasets.cpp
+++ b/StaticFusion-datasets.cpp
@@ -52,9 +52,8 @@
 
 #include <opencv2/core/eigen.hpp>
 
-int main()
-{	
-
+int main(int argc, char* argv[])
+{
     unsigned int res_factor = 2;
     StaticFusion staticFusion(res_factor);
 
@@ -64,6 +63,14 @@ int main()
 
     const bool save_results = true;
     Datasets dataset(res_factor);
+
+    if(argc<2) {
+        throw std::runtime_error("missing log file");
+    }
+    else {
+        //Set dir of the Rawlog file
+        dataset.filename = argv[1];
+    }
 
     //Parameters
     //----------------------------------------------------------
@@ -92,9 +99,6 @@ int main()
     //Map
     cv::Mat depth_full = cv::Mat(staticFusion.height, staticFusion.width,  CV_16U, 0.0);
     cv::Mat color_full = cv::Mat(staticFusion.height, staticFusion.width,  CV_8UC3,  cv::Scalar(0,0,0));
-
-    //Set dir of the Rawlog file
-     dataset.filename = "/home/datasets/tum-benchmark-mrpt/rawlog_rgbd_dataset_freiburg3_walking_xyz/rgbd_dataset_freiburg3_walking_xyz.rawlog";
 
 	//Initialize
 	if (save_results)

--- a/StaticFusion-imagesequenceassoc.cpp
+++ b/StaticFusion-imagesequenceassoc.cpp
@@ -87,9 +87,13 @@ int main(int argc, char* argv[])
     std::vector<std::string> filesDepth;
     std::vector<std::string> filesColor;
 
-    std::string assocFile = "rgbd_assoc.txt";
+    const std::string assocFile = "/rgbd_assoc.txt";
 
     staticFusion.loadAssoc(dir, assocFile, timestamps, filesDepth, filesColor);
+
+    if (filesDepth.empty() || filesColor.empty()) {
+        throw std::runtime_error("no image files");
+    }
 
     cv::Mat weightedImage;
 

--- a/StaticFusion-imagesequenceassoc.cpp
+++ b/StaticFusion-imagesequenceassoc.cpp
@@ -46,8 +46,14 @@
 #include <iostream>
 #include <fstream>
 
-int main()
-{	
+int main(int argc, char* argv[])
+{
+    if(argc<2) {
+        throw std::runtime_error("missing log file");
+    }
+
+    const std::string dir = argv[1];
+
     const unsigned int res_factor = 2;
     StaticFusion staticFusion(res_factor);
 
@@ -76,8 +82,6 @@ int main()
     //Set first image to load, decimation factor and the sequence dir
     int im_count = 1;
     const unsigned int decimation = 1;
-
-    std::string dir = "/home/datasets/mariano-ball/";
 
     std::vector<double> timestamps;
     std::vector<std::string> filesDepth;

--- a/Utils/Parse.cpp
+++ b/Utils/Parse.cpp
@@ -61,7 +61,7 @@ int Parse::arg(int argc, char** argv, const char* str, int &val) const
 
 std::string Parse::shaderDir() const
 {
-    std::string currentVal = STR(SHADER_DIR);
+    const std::string currentVal = SHADER_DIR;
 
     assert(pangolin::FileExists(currentVal) && "Shader directory not found!");
 

--- a/Utils/Parse.h
+++ b/Utils/Parse.h
@@ -34,9 +34,6 @@
 #include <string>
 #include <iostream>
 
-#define XSTR(x) #x
-#define STR(x) XSTR(x)
-
 class Parse
 {
     public:


### PR DESCRIPTION
Minor changes to load dataset paths from the command line and make it work with the examples.

I am unsure about the `labels_maxres(v,u)` which would sometimes returns 24, i.e. the number of clusters and further create an error when accessing arrays, e.g. `b_segm`. I've seen this with the `ball` and the `freiburg3_walking` sequences.

I suspect this comes if the depth is exactly 0, i.e. invalid: https://github.com/raluca-scona/staticfusion/blob/2abd6e57cbee65c22e54b469c178a624fe5d77d2/KMeans.cpp#L265
If this happens, I set the b-weight to 1, i.e. assume that the invalid depth is static. Is there a better way to deal with the invalid depth and the cluster centres?

I also had to enable C++17 to fix an assertion:
http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html